### PR TITLE
Исправление ошибки десериализации

### DIFF
--- a/src/KinopoiskUnofficialInfo.ApiClient/GeneratedClient.generated.cs
+++ b/src/KinopoiskUnofficialInfo.ApiClient/GeneratedClient.generated.cs
@@ -3948,6 +3948,9 @@ namespace KinopoiskUnofficialInfo.ApiClient
         [System.Runtime.Serialization.EnumMember(Value = @"UNKNOWN")]
         UNKNOWN = 2,
     
+        [System.Runtime.Serialization.EnumMember(Value = @"YANDEX_DISK")]
+        YANDEX_DISK = 3,
+    
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.11.1.0 (NJsonSchema v10.4.3.0 (Newtonsoft.Json v12.0.0.0))")]


### PR DESCRIPTION
Текст ошибки:

```
KinopoiskUnofficialInfo.ApiClient.ApiException: Could not deserialize the response body stream as KinopoiskUnofficialInfo.ApiClient.VideoResponse.

---> Newtonsoft.Json.JsonSerializationException: Error converting value "YANDEX_DISK" to type 'KinopoiskUnofficialInfo.ApiClient.VideoResponse_itemsSite'. Path 'items[0].site', line 1, position 109.
2024-06-24 19:06:47.649054+07:00---> System.ArgumentException: Requested value 'YANDEX_DISK' was not found.
```